### PR TITLE
Add 21H2 ADK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,18 @@
+name: Build
+on:
+  - push
+  - pull_request
+jobs:
+  build:
+    name: Build
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: PowerShell -File build.ps1
+      - name: Archive
+        uses: actions/upload-artifact@v2
+        with:
+          name: packages
+          path: |
+            *.nupkg

--- a/MDT/ADK.21H2.Chocolatey.ps1
+++ b/MDT/ADK.21H2.Chocolatey.ps1
@@ -1,0 +1,25 @@
+$ChocoPackagePE = @{
+    Version = '10.1.22000.1'
+    Tags = 'ADK Winpe WAIK'
+    packageName = 'WinPE add-on for the Windows Assessment and Deployment Kit'
+    friendlyUrl = 'https://docs.microsoft.com/en-us/windows-hardware/get-started/adk-install'
+    Summary = 'The Windows Assessment and Deployment Kit (Windows ADK) is a collection of tools that you can use to customize, assess, and deploy Windows operating systems to new computers. Installs WinPE ONLY!'
+    url = 'https://go.microsoft.com/fwlink/?linkid=2166133'
+}
+
+& $PSScriptRoot\..\Common\Create-ChocolateyExePackage.ps1 -Path $PSSCriptRoot\build\$Version @ChocoPackagePE -ID 'windows-adk-winpe' -Features 'winpe' -args "/quiet /norestart /log $env:temp\winPE_adk.log /features +"
+
+$CommonArgs = '/quiet /norestart /log $env:temp\win_adk.log'
+
+$ChocoPackageADK = @{
+    Version = '10.1.22000.1'
+    Tags = 'ADK Winpe WAIK USMT'
+    packageName = 'Windows Assessment and Deployment Kit'
+    friendlyUrl = 'https://docs.microsoft.com/en-us/windows-hardware/get-started/adk-install'
+    Summary = 'The Windows Assessment and Deployment Kit (Windows ADK) is a collection of tools that you can use to customize, assess, and deploy Windows operating systems to new computers.'
+    url = 'https://go.microsoft.com/fwlink/?linkid=2165884'
+}
+
+& $PSScriptRoot\..\Common\Create-ChocolateyExePackage.ps1 -Path $PSSCriptRoot\build\$Version @ChocoPackageADK -ID 'windows-adk' -Features 'default' -args "$CommonArgs"
+& $PSScriptRoot\..\Common\Create-ChocolateyExePackage.ps1 -Path $PSSCriptRoot\build\$Version @ChocoPackageADK -ID 'windows-adk-all' -Features 'all' -args "$CommonArgs /features +" -Dependency "id=""windows-adk-winpe"" version = ""$($ChocoPackagePE.Version)"""
+& $PSScriptRoot\..\Common\Create-ChocolateyExePackage.ps1 -Path $PSSCriptRoot\build\$Version @ChocoPackageADK -ID 'windows-adk-deploy' -Features 'common deployment' -args "$CommonArgs /features OptionId.DeploymentTools OptionId.ImagingAndConfigurationDesigner OptionId.UserStateMigrationTool"  -Dependency "id=""windows-adk-winpe"" version = ""$($ChocoPackagePE.Version)"""

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
+[![Build status](https://github.com/rgl/keithga-Chocolatey/workflows/Build/badge.svg)](https://github.com/rgl/keithga-Chocolatey/actions?query=workflow%3ABuild)
+
 # Chocolatey
+
 Public scripts and sources for my Chocolatey Projects

--- a/build.ps1
+++ b/build.ps1
@@ -1,10 +1,10 @@
 
 [CmdletBinding()]
 param(
-     [string] $Filter = "$PSScriptRoot\*.chocolatey.ps1"
+     [string] $Filter = "$PSScriptRoot\MDT\*.chocolatey.ps1"
     )
 
-Remove-Item -Recurse -Force $PSScriptRoot\build -ErrorAction SilentlyContinue
+Remove-Item -Recurse -Force $PSScriptRoot\MDT\build -ErrorAction SilentlyContinue
 
 foreach ( $MyScript in get-childitem $Filter  )
 {


### PR DESCRIPTION
This add ADK 21H2 (Windows 11) to fix https://github.com/keithga/Chocolatey/issues/2.

I also took the opportunity to add a GitHub Actions workflow to automatically build all the packages. You can see it in action at https://github.com/rgl/keithga-Chocolatey/actions; it leaves all the packages as artifacts at the build page. To use this in your repository you should modify the url that is at the top of the README.md file.

There are some packages that are failing with 404 errors. Probably the build should have failed when that happens.